### PR TITLE
Remove directions right arrow when no address is available

### DIFF
--- a/site/pdxroasters/templates/partials/roaster_detail.html
+++ b/site/pdxroasters/templates/partials/roaster_detail.html
@@ -3,7 +3,9 @@
         <a class="back-to-list" href="#"> </a>
         <div class="banner-title">
             <h1 class="roaster-title"> {{ roaster.name }} </h1>
+            {% if roaster.address %}
             <p class="banner-address"> <a class="banner-link" href="http://maps.google.com/maps?daddr={{ roaster.lat }},{{ roaster.lng }}" target="_blank"> {{ roaster.address|linebreaksbr }} </a> </p>
+            {% endif %}
         </div>
     </div>
     <div class="group roaster-description" id="roaster-description">


### PR DESCRIPTION
We've added a right arrow directions icon to detail pages. However we need to make it so this dose not display when no address is available

![screen shot 2013-05-29 at 7 41 42 pm](https://f.cloud.github.com/assets/3312529/582975/c8601d94-c8d2-11e2-8b55-dc883c7a016e.png)
. 
