### PR TITLE
prevent roaster pages form loading main.js

### DIFF
--- a/site/pdxroasters/templates/about.html
+++ b/site/pdxroasters/templates/about.html
@@ -6,8 +6,6 @@
 {% block page %}aboutPage{% endblock %}
 {% block aboutActive %}active{% endblock %}
 
-{% block script %}about{% endblock %}
-
 {% block content %}
   <!-- About -->
   <section id="about">
@@ -78,4 +76,8 @@
       </section>
     </div>
   </section>
+{% endblock %}
+
+{% block scripts %}
+  <script src="/static/js/dist/about.min.js"></script>
 {% endblock %}

--- a/site/pdxroasters/templates/home.html
+++ b/site/pdxroasters/templates/home.html
@@ -62,3 +62,7 @@
   </section>
 {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  <script src="/static/js/dist/main.min.js"></script>
+{% endblock %}

--- a/site/pdxroasters/templates/site_base.html
+++ b/site/pdxroasters/templates/site_base.html
@@ -58,7 +58,7 @@
   </section>
 
   <!-- Load JS -->
-  <script src="/static/js/dist/{% block script %}main{% endblock %}.min.js"></script>
+  {% block scripts %}{% endblock %}
 
   {% if not debug %}
     <script>


### PR DESCRIPTION
Just noticed that the roaster pages are still trying to load the main js file, even though they don't need any js.

This fixes that problem. Each page can now set content for a `scripts` block.
